### PR TITLE
Rename updated property names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export {Rule as SwitchIdentifiersRule} from './rules/switchIdentifiersRule';
 export {Rule as SwitchStringLiteralsRule} from './rules/switchStringLiteralsRule';
 export {Rule as SwitchTemplatesRule} from './rules/switchTemplatesRule';
 export {Rule as SwitchStylesheetsRule} from './rules/switchStylesheetsRule';
+export {Rule as SwitchPropertyNamesRule} from './rules/switchPropertyNamesRule';

--- a/src/material/component-data.ts
+++ b/src/material/component-data.ts
@@ -19,5 +19,8 @@ export const exportAsNames: MaterialNameData[] = require('./data/export-as-names
 /** Export the attribute selectors data as part of a module. This means that the data is cached. */
 export const attributeSelectors: MaterialNameData[] = require('./data/attribute-selectors.json');
 
+/** Export the property names as part of a module. This means that the data is cached. */
+export const propertyNames: MaterialNameData[] = require('./data/property-names.json');
+
 /** Method that can be used to remove the surrounding Angular attribute brackets from a string. */
 export const removeAttributeBackets = (str) => str.substring(1, str.length - 1);

--- a/src/material/data/input-names.json
+++ b/src/material/data/input-names.json
@@ -86,5 +86,9 @@
   {
     "md": "mdTooltipShowDelay",
     "mat": "matTooltipShowDelay"
+  },
+  {
+    "md": "mdSortChange",
+    "mat": "matSortChange"
   }
 ]

--- a/src/material/data/property-names.json
+++ b/src/material/data/property-names.json
@@ -1,0 +1,6 @@
+[
+  {
+    "md": "mdSortChange",
+    "mat": "sortChange"
+  }
+]

--- a/src/rules/switchPropertyNamesRule.ts
+++ b/src/rules/switchPropertyNamesRule.ts
@@ -1,0 +1,40 @@
+import {Rules, RuleFailure, RuleWalker} from 'tslint';
+import {propertyNames} from "../material/component-data";
+import * as ts from 'typescript';
+
+/** Message that is being sent to TSLint if a string literal still uses the outdated prefix. */
+const failureMessage = 'Property access expression can be switched from "Md" prefix to "Mat".';
+
+/**
+ * Rule that walks through every property access expression and updates properties that have
+ * been changed in favor of the new prefix.
+ */
+export class Rule extends Rules.AbstractRule {
+
+  apply(sourceFile: ts.SourceFile): RuleFailure[] {
+    return this.applyWithWalker(new SwitchPropertyNamesWalker(sourceFile, this.getOptions()));
+  }
+}
+
+export class SwitchPropertyNamesWalker extends RuleWalker {
+
+  visitPropertyAccessExpression(prop: ts.PropertyAccessExpression) {
+    // Recursively call this method for the expression of the current property expression.
+    // It can happen that there is a chain of property access expressions.
+    // For example: "mySortInstance.mdSortChange.subscribe()"
+    if (prop.expression && prop.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+      this.visitPropertyAccessExpression(prop.expression as ts.PropertyAccessExpression);
+    }
+
+    const propertyData = propertyNames.find(name => prop.name.getText() === name.md);
+
+    if (!propertyData) {
+      return;
+    }
+
+    const replacement = this.createReplacement(prop.name.getStart(),
+        prop.name.getWidth(), propertyData.mat);
+
+    this.addFailureAtNode(prop.name, failureMessage, replacement);
+  }
+}

--- a/src/rules/tslint-migration.json
+++ b/src/rules/tslint-migration.json
@@ -4,6 +4,7 @@
     "switch-identifiers": true,
     "switch-string-literals": true,
     "switch-templates": true,
-    "switch-stylesheets": true
+    "switch-stylesheets": true,
+    "switch-property-names": true
   }
 }

--- a/test/fixtures/sample-project/app/app.component.spec.ts
+++ b/test/fixtures/sample-project/app/app.component.spec.ts
@@ -1,4 +1,6 @@
 import {By} from '@angular/platform-browser';
+import {MdSort} from '@angular/material';
+import {Observable} from "rxjs/Observable";
 
 describe('App Component', () => {
 
@@ -7,6 +9,12 @@ describe('App Component', () => {
 
     // This can be considered as invalid, since the button is always an attribute and no selector.
     const debugElement2 = By.css('md-button');
+
+    // Fakes the old MatSort implementation with the old output property.
+    const sort: {mdSortChange: Observable<void>} & MdSort = null;
+
+    // This property has been updated as part of the prefix switching.
+    sort.mdSortChange.subscribe(() => {});
   });
 
 });


### PR DESCRIPTION
* Properties like `mdSortChange` have been renamed to `sortChange` in favor of the new prefix.

Fixes #4 