### PR TITLE
fix(): replace outdated stepper imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,49 +1,33 @@
 {
   "name": "angular-material-prefix-updater",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@angular/cdk": {
       "version": "github:angular/cdk-builds#f2c84db4471dbdbc1dc5ae406589cf1f15f0aaca",
-      "dev": true,
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "dev": true
     },
     "@angular/common": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.3.3.tgz",
       "integrity": "sha1-H6++ozr066TN3YZ371eg92pQSIw=",
-      "dev": true,
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "dev": true
     },
     "@angular/core": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.3.3.tgz",
       "integrity": "sha1-jmp2kUZh20B/otiN0kQcTAFv9iU=",
-      "dev": true,
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "dev": true
     },
     "@angular/material": {
       "version": "github:angular/material2-builds#a7743d267e176592889906b531bb8e5a88a8c605",
-      "dev": true,
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "dev": true
     },
     "@angular/platform-browser": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.3.3.tgz",
       "integrity": "sha1-Yjtll5TweQltT3aFtL68tJ47mnE=",
-      "dev": true,
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "dev": true
     },
     "@types/chalk": {
       "version": "0.4.31",
@@ -55,11 +39,7 @@
       "version": "5.0.32",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.32.tgz",
       "integrity": "sha512-DMcj5b67Alb/e4KhpzyvphC5nVDHn1oCOGZao3oBddZVMH5vgI/cvdp+O/kcxZGZaPqs0ZLAsK4YrjbtZHO05g==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.17"
-      }
+      "dev": true
     },
     "@types/jasmine": {
       "version": "2.5.53",
@@ -83,10 +63,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.1.tgz",
       "integrity": "sha512-K9nqHo2rzMfM1KJW5F8uGYx1dmWzF2bJyn1sQ5v+NXQO14p/+8FWQk3//sbBYlmftf83pV9HGIG9X2GtknIrGg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.0.17"
-      }
+      "dev": true
     },
     "@types/yargs": {
       "version": "8.0.1",
@@ -102,10 +79,7 @@
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "requires": {
-        "color-convert": "1.9.0"
-      }
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug=="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -117,10 +91,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -138,11 +109,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -152,14 +118,7 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
         },
         "supports-color": {
           "version": "2.0.0",
@@ -176,11 +135,7 @@
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -197,10 +152,6 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      },
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
@@ -213,20 +164,12 @@
     "chalk": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-      "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.2.1"
-      }
+      "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g=="
     },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU="
     },
     "cli-spinners": {
       "version": "1.0.1",
@@ -237,21 +180,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      },
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
         }
       }
     },
@@ -263,10 +196,7 @@
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o="
     },
     "color-name": {
       "version": "1.1.3",
@@ -298,59 +228,30 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-3.2.0.tgz",
       "integrity": "sha1-b4NhYlRiTwrViqSqjQdvAmvn4Yg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "nested-error-stacks": "1.0.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
-      }
+      "dev": true
     },
     "cpy": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/cpy/-/cpy-4.0.1.tgz",
       "integrity": "sha1-tnJn66LzlgugalphrJQDNCKDNCQ=",
-      "dev": true,
-      "requires": {
-        "cp-file": "3.2.0",
-        "globby": "4.1.0",
-        "meow": "3.7.0",
-        "nested-error-stacks": "1.0.2",
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "cpy-cli": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cpy-cli/-/cpy-cli-1.0.1.tgz",
       "integrity": "sha1-Z/taSi3sKMqKv/N13kuecfanVhw=",
-      "dev": true,
-      "requires": {
-        "cpy": "4.0.1",
-        "meow": "3.7.0"
-      }
+      "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.2.14"
-      }
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk="
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
+      "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
@@ -365,10 +266,7 @@
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -383,16 +281,7 @@
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      }
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c="
     },
     "find-parent-dir": {
       "version": "0.3.0",
@@ -402,10 +291,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "requires": {
-        "locate-path": "2.0.0"
-      }
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -431,42 +317,19 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
     },
     "globby": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
       "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "6.0.4",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
       "dependencies": {
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -478,10 +341,7 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-flag": {
       "version": "2.0.0",
@@ -497,19 +357,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
     },
     "inherits": {
       "version": "2.0.3",
@@ -529,27 +382,18 @@
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -581,38 +425,22 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
     },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
-      }
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg="
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      }
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4="
     },
     "log-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "requires": {
-        "chalk": "1.1.3"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -622,14 +450,7 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
         },
         "supports-color": {
           "version": "2.0.0",
@@ -642,20 +463,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
     },
     "make-error": {
       "version": "1.3.0",
@@ -672,101 +485,55 @@
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y="
     },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "load-json-file": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "path-type": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
+          "dev": true
         },
         "read-pkg-up": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
+          "dev": true
         },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "dev": true
         }
       }
     },
@@ -778,10 +545,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "minimist": {
       "version": "1.2.0",
@@ -794,9 +558,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -810,29 +571,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
       "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw=="
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "2.0.1"
-      }
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -848,29 +597,17 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ="
     },
     "ora": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-1.3.0.tgz",
       "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.0.1",
-        "log-symbols": "1.0.2"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
@@ -880,14 +617,7 @@
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
         },
         "supports-color": {
           "version": "2.0.0",
@@ -899,12 +629,7 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
-      }
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA=="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -919,18 +644,12 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "requires": {
-        "p-limit": "1.1.0"
-      }
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM="
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -955,10 +674,7 @@
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "requires": {
-        "pify": "2.3.0"
-      }
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM="
     },
     "pify": {
       "version": "2.3.0",
@@ -975,10 +691,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -994,55 +707,30 @@
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
-      }
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg="
     },
     "read-pkg-up": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
-      }
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4="
     },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
+      "dev": true
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -1057,36 +745,23 @@
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q=="
     },
     "resolve-bin": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.0.tgz",
-      "integrity": "sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk=",
-      "requires": {
-        "find-parent-dir": "0.3.0"
-      }
+      "integrity": "sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk="
     },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368="
     },
     "rxjs": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
       "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "1.0.4"
-      }
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -1107,10 +782,7 @@
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -1132,18 +804,12 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -1155,14 +821,16 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -1177,29 +845,14 @@
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8="
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -1215,10 +868,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -1229,10 +879,7 @@
     "supports-color": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-      "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-      "requires": {
-        "has-flag": "2.0.0"
-      }
+      "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA=="
     },
     "symbol-observable": {
       "version": "1.0.4",
@@ -1250,29 +897,13 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "chalk": "2.0.1",
-        "diff": "3.3.0",
-        "make-error": "1.3.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15",
-        "tsconfig": "6.0.0",
-        "v8flags": "3.0.0",
-        "yn": "2.0.0"
-      }
+      "dev": true
     },
     "tsconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1"
-      }
+      "dev": true
     },
     "tslib": {
       "version": "1.7.1",
@@ -1282,27 +913,12 @@
     "tslint": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.7.0.tgz",
-      "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
-        "commander": "2.11.0",
-        "diff": "3.3.0",
-        "glob": "7.1.2",
-        "minimatch": "3.0.4",
-        "resolve": "1.4.0",
-        "semver": "5.4.1",
-        "tslib": "1.7.1",
-        "tsutils": "2.8.2"
-      }
+      "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI="
     },
     "tsutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.2.tgz",
-      "integrity": "sha1-LBSGukMSYIRbCsb5Aq/Z1wio6mo=",
-      "requires": {
-        "tslib": "1.7.1"
-      }
+      "integrity": "sha1-LBSGukMSYIRbCsb5Aq/Z1wio6mo="
     },
     "typescript": {
       "version": "2.4.2",
@@ -1325,27 +941,17 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.0.tgz",
       "integrity": "sha512-AGl+C+4qpeSu2g3JxCD/mGFFOs/vVZ3XREkD3ibQXEqr4Y4zgIrPWW124/IKJFHOIVFIoH8miWrLf0o84HYjwA==",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
     },
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
     },
     "which-module": {
       "version": "2.0.0",
@@ -1356,20 +962,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      },
       "dependencies": {
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
         }
       }
     },
@@ -1391,30 +988,12 @@
     "yargs": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-      "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
-      }
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A="
     },
     "yargs-parser": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "requires": {
-        "camelcase": "4.1.0"
-      }
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k="
     },
     "yn": {
       "version": "2.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,7 +82,8 @@ function migrateProject(tslintArgs: string[], env?: any) {
       console.error(`\n${stderr.trim()}\n`);
       console.error(yellow('Make sure the following things are done correctly:'));
       console.error(yellow(' • Angular Material is installed in the project (for type checking)'));
-      console.error(yellow(' • Project "tsconfig.json" configuration matches the desired files.'));
+      console.error(yellow(' • The Angular Material version is not higher than "beta.11"'))      
+      console.error(yellow(' • Project "tsconfig.json" configuration matches the desired files'));
       console.error();
       spinner.fail('Errors occurred while migrating the Angular Material project.');
     } else {

--- a/src/material/data/attribute-selectors.json
+++ b/src/material/data/attribute-selectors.json
@@ -300,5 +300,9 @@
   {
     "md": "[mdTooltip]",
     "mat": "[matTooltip]"
+  },
+  {
+    "md": "[mdStepper]",
+    "mat": "[matStepper]"
   }
 ]

--- a/src/material/data/class-names.json
+++ b/src/material/data/class-names.json
@@ -982,5 +982,33 @@
   {
     "md": "MdSuffix",
     "mat": "MatSuffix"
+  },
+  {
+    "md": "MdStepHeader",
+    "mat": "MatStepHeader"
+  },
+  {
+    "md": "MdStepLabel",
+    "mat": "MatStepLabel"
+  },
+  {
+    "md": "MdStep",
+    "mat": "MatStep"
+  },
+  {
+    "md": "MdStepper",
+    "mat": "MatStepper"
+  },
+  {
+    "md": "MdHorizontalStepper",
+    "mat": "MatHorizontalStepper"
+  },
+  {
+    "md": "MdVerticalStepper",
+    "mat": "MatVerticalStepper"
+  },
+  {
+    "md": "MdStepperModule",
+    "mat": "MatStepperModule"
   }
 ]

--- a/src/material/data/element-selectors.json
+++ b/src/material/data/element-selectors.json
@@ -302,5 +302,17 @@
   {
     "md": "md-year-view",
     "mat": "mat-year-view"
+  },
+  {
+    "md": "md-step",
+    "mat": "mat-step"
+  },
+  {
+    "md": "md-horizontal-stepper",
+    "mat": "mat-horizontal-stepper"
+  },
+  {
+    "md": "md-vertical-stepper",
+    "mat": "mat-vertical-stepper"
   }
 ]

--- a/src/tslint/component-walker.ts
+++ b/src/tslint/component-walker.ts
@@ -36,6 +36,10 @@ export class ComponentWalker extends RuleWalker {
   private _visitDirectiveCallExpression(callExpression: ts.CallExpression) {
     const directiveMetadata = callExpression.arguments[0] as ts.ObjectLiteralExpression;
 
+    if (!directiveMetadata) {
+      return;
+    }
+
     for (const property of directiveMetadata.properties as ts.NodeArray<ts.PropertyAssignment>) {
       const propertyName = property.name.getText();
       const initializerKind = property.initializer.kind;

--- a/src/tslint/find-tslint-binary.ts
+++ b/src/tslint/find-tslint-binary.ts
@@ -2,16 +2,15 @@ import {resolve} from 'path';
 import {existsSync} from 'fs';
 
 // This import lacks of type definitions.
-const resolveBin = require('resolve-bin').sync;
+const resolveBinSync = require('resolve-bin').sync;
 
 /** Finds the path to the TSLint CLI binary. */
 export function findTslintBinaryPath() {
   const defaultPath = resolve(__dirname, '..', 'node_modules', 'tslint', 'bin', 'tslint');
-  const resolvedPath = resolveBin('tslint', 'tslint');
 
   if (existsSync(defaultPath)) {
     return defaultPath;
   } else {
-    return resolvedPath;
+    return resolveBinSync('tslint', 'tslint');
   }
 }


### PR DESCRIPTION
* Fixes that stepper selectors, class names are not being updated
* Better error messages if symbol could not be resolved.
* Instructions after successful migration
* Note about required Angular Material version on migration failure.
* Better TSLint binary resolving without runtime exception from `resolveBin`.
* Safety check in `ComponentWalker` for decorators without metadata.